### PR TITLE
Support replacing canteens by other canteens

### DIFF
--- a/app/controllers/api/v2/canteens_controller.rb
+++ b/app/controllers/api/v2/canteens_controller.rb
@@ -31,4 +31,13 @@ class Api::V2::CanteensController < Api::BaseController
   def find_collection
     apply_scopes Canteen.active.order(:id)
   end
+
+  def find_resource
+    canteen = super
+    if canteen.replaced?
+      return canteen.replaced_by
+    else
+      canteen
+    end
+  end
 end

--- a/app/controllers/canteens_controller.rb
+++ b/app/controllers/canteens_controller.rb
@@ -56,6 +56,9 @@ class CanteensController < ApplicationController
 
   def load_resource
     @canteen = Canteen.find params[:id]
+    if @canteen.replaced?
+      @canteen = @canteen.replaced_by
+    end
   end
 
   def new_resource

--- a/app/models/canteen.rb
+++ b/app/models/canteen.rb
@@ -10,6 +10,7 @@ class Canteen < ApplicationRecord
   has_many :feeds, through: :sources
   has_many :data_proposals
   has_many :feedbacks
+  belongs_to :replaced_by, class_name: 'Canteen', foreign_key: :replaced_by, optional: true
 
   scope :active, -> { where('state IN (?)', ['active', 'empty']) }
 
@@ -40,5 +41,9 @@ class Canteen < ApplicationRecord
 
   def archived?
     state == 'archived'
+  end
+
+  def replaced?
+    !read_attribute(:replaced_by).nil?
   end
 end

--- a/db/migrate/20180117105826_add_replaced_by_to_canteens.rb
+++ b/db/migrate/20180117105826_add_replaced_by_to_canteens.rb
@@ -1,0 +1,5 @@
+class AddReplacedByToCanteens < ActiveRecord::Migration[5.1]
+  def change
+    add_column :canteens, :replaced_by, :integer, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170317110435) do
+ActiveRecord::Schema.define(version: 20180117105826) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,6 +29,7 @@ ActiveRecord::Schema.define(version: 20170317110435) do
     t.string "email"
     t.boolean "availibility", default: true
     t.string "openingTimes", array: true
+    t.integer "replaced_by"
   end
 
   create_table "comments", id: :serial, force: :cascade do |t|

--- a/spec/controllers/api/v2/canteens_controller_spec.rb
+++ b/spec/controllers/api/v2/canteens_controller_spec.rb
@@ -327,5 +327,21 @@ describe Api::V2::CanteensController, type: :controller do
         its(['id']) { should be canteen.id }
       end
     end
+
+    context 'and a replaced canteens' do
+      let(:replacement) { FactoryGirl.create :canteen, state: 'active'}
+      let(:canteen) { FactoryGirl.create :canteen, state: 'archived', replaced_by: replacement }
+      subject { json }
+
+      context 'response' do
+        subject { response }
+        its(:status) { should == 200 }
+      end
+
+      context 'json' do
+        subject { json }
+        its(['id']) { should be replacement.id }
+      end
+    end
   end
 end

--- a/spec/controllers/canteens_controller_spec.rb
+++ b/spec/controllers/canteens_controller_spec.rb
@@ -24,6 +24,18 @@ describe CanteensController, type: :controller do
       expect(assigns(:date)).to eq (Time.zone.now + 1.day).to_date
       expect(assigns(:meals)).to eq canteen.meals.for(Time.zone.now + 1.day)
     end
+
+    context ' with replaced canteen' do
+      let(:replaced) { FactoryGirl.create :canteen, state: 'archived', replaced_by: canteen }
+      it 'asdf' do
+        get :show, params: {id: replaced.id}
+
+        expect(assigns(:canteen)).to eq canteen
+
+        expect(assigns(:date)).to eq Date.today
+        expect(assigns(:meals)).to eq canteen.meals.for(Time.zone.now)
+      end
+    end
   end
 
   describe '#update' do


### PR DESCRIPTION
From time to time multiple canteen objects are created for one
physical facility.
To keep URLs static this PR adds a replaced_by field to canteens.
Accessing such replaced canteens returns the data of the references
data instead.

At the momenten the feature can only be activated by admins.
UI support might be added later on if it is used more frequently.