### PR TITLE
add support for sentry/raven

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,8 @@ gem 'baby_squeel'
 
 gem 'pg', '~> 1.0' # missing compability with rails
 
+gem 'sentry-raven'
+
 group :assets do
   gem 'autoprefixer-rails', '~> 9.5'
   gem 'sass-rails', '~> 5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -332,6 +332,8 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    sentry-raven (2.9.0)
+      faraday (>= 0.7.6, < 1.0)
     shellany (0.0.1)
     simplecov (0.16.1)
       docile (~> 1.1)
@@ -437,6 +439,7 @@ DEPENDENCIES
   rubocop (~> 0.58.1)
   rubocop-rspec (~> 1.29)
   sass-rails (~> 5.0)
+  sentry-raven
   simplecov
   simplecov-rcov
   slim

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Configure Sentry-Raven if raven_dsn secret is set
+
+if Rails.application.secrets.raven_dsn
+  Raven.configure do |config|
+    config.dsn = Rails.application.secrets.raven_dsn
+    config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
+  end
+end


### PR DESCRIPTION
This PR allows OpenMensa to be monitored by a Sentry instance (or anything compatible) just by adding a Sentry DSN to the secrets.yml.