### PR TITLE
fix: typo and confusing sentence

### DIFF
--- a/app/views/parsers/new.html.slim
+++ b/app/views/parsers/new.html.slim
@@ -5,11 +5,11 @@
         h2 = t :create_parser
       .content
         p
-          ' Wir freuen uns über deine Unterstüztung zu OpenMensa.
+          ' Wir freuen uns über deine Unterstützung zu OpenMensa.
           ' Du bist dabei einen neuen Parser hinzuzufügen.
-          ' Damit werden für eine Menge verbundenen Mensa
-          ' Speisepläne und weitergehende Information für OpenMensa
-          ' konform bereitgestellt.
+          ' Damit werden für zusätzliche Mensen die Speisepläne
+          ' und weitere Informationen in einer für OpenMensa
+          ' geeigneten Form zur Verfügung gestellt.
         p
           ' Bitte lies - sofern noch nicht geschehen - die
           a href="https://doc.openmensa.org/parsers/" Erklärungen über Parser


### PR DESCRIPTION
Fix for typo ~~Unterstüztung~~ -> Unterstützung.

Propose new sentence structure for following sentence, feel free to adjust.