### PR TITLE
feat: Hint search engines to primary canteen page

### DIFF
--- a/app/controllers/canteens_controller.rb
+++ b/app/controllers/canteens_controller.rb
@@ -16,6 +16,11 @@ class CanteensController < WebController
             end
 
     @meals = @canteen.meals.for @date
+    @title = @canteen.name
+
+    response.link canteen_url(@canteen), rel: :canonical
+    response.link canteen_url(@canteen, date: (@date + 1.day)), rel: :next
+    response.link canteen_url(@canteen, date: (@date - 1.day)), rel: :prev
   end
 
   def edit; end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -42,7 +42,7 @@ module ApplicationHelper
   # These instance variables are intended here.
   # rubocop:disable Rails/HelperInstanceVariable
   def title
-    "#{@title} - #{OpenMensa::TITLE}" unless @title
+    return "#{@title} - #{OpenMensa::TITLE}" if @title
     OpenMensa::TITLE
   end
 
@@ -85,5 +85,13 @@ module ApplicationHelper
       fetch_up_to_date: :"fa-solid fa-check",
       fetch_needed: :"fa-solid fa-triangle-exclamation"
     }[fetch_state]
+  end
+
+  def render_head_response_links
+    capture do
+      response.links.each do |link|
+        concat content_tag(:link, nil, href: link[:url], **link[:params])
+      end
+    end
   end
 end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -26,6 +26,7 @@ html
     meta content="#ffffff" name="msapplication-TileColor" /
     meta content="/ms-icon-144x144.png" name="msapplication-TileImage" /
     meta content="#ffffff" name="theme-color" /
+    = render_head_response_links
 
   body class=body_classes
     section#content


### PR DESCRIPTION
Add canonical URL links to the primary canteen page so that search engines prefer redirecting users to the current (today) canteen page.

Further, add the canteen name to the page title for increased visibility.