### PR TITLE
fix: double render error on menu when no signed in

### DIFF
--- a/app/controllers/menu_controller.rb
+++ b/app/controllers/menu_controller.rb
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
 class MenuController < WebController
+  skip_authorization_check only: :show
+
   def show
-    require_authentication!
-    authorize! :show, @user
+    unless current_user.logged?
+      redirect_to root_url
+      return
+    end
+
     @date = if params[:date]
               Date.parse params[:date].to_s
             else


### PR DESCRIPTION
When not logged in, opening `/menu` resulted in a double render error
because `render/redirect_to` is called twice.

The double rendering isn't obvious, but is caused by calling
`#require_authentication!` and `authorize!` explicitly inside the action
method.

`#require_authentication!` is only intended to be used as a before
filter. If unauthorized, it will `error_access_denied` and return false,
which would abort if used as a before filter, but not when called
manually. Afterwards, the action calls `authorize!`, which raises an
error (CanCan::AccessDenied). That exception is handled in the
application controller and leads to calling `#error_access_denied`
again, trying to render a second time.

This CL removes the second `#authorize!` check, and, to avoid showing an
error page, redirects to the root page if the user isn't logged in.

Fixes OPENMENSA-28