### PR TITLE
feat: Improve user and developer mode forms

### DIFF
--- a/app/javascripts/_form.scss
+++ b/app/javascripts/_form.scss
@@ -109,6 +109,8 @@ form {
       color: #555;
 
       margin: 0 0.2em;
+
+      max-width: 396px;
     }
 
     .form-check {

--- a/app/locales/de.yml
+++ b/app/locales/de.yml
@@ -324,6 +324,8 @@ de:
     submit:
       source:
         create: Hinzufügen
+      user:
+        update: Speichern
 
   date:
     formats:
@@ -426,6 +428,9 @@ de:
       feed_fetch:
         one: Feed-Abruf
         other: Feed-Abrufe
+      user:
+        one: Benutzer
+        other: Benutzer
     attributes:
       canteen:
         address: Adresse
@@ -444,6 +449,14 @@ de:
         canteen: Mensa
         meta_url: Meta-URL
         name: Name
+      user:
+        name: Name
+        login: Login-ID
+        email: E-Mail
+        notify_email: E-Mail für Fehlerberichte
+        public_name: Öffentlicher Name
+        public_email: Öffentliche E-Mail
+        info_url: Webseite
 
   mailer:
     daily_report:
@@ -510,13 +523,19 @@ de:
     "yes": "Ja"
     "no": "Nein"
     required:
-      text: "Notwendigs Feld"
+      text: "Notwendiges Feld"
       mark: "*"
     hints:
       parser:
         info_url: Wird auf der Mensa-Seite öffentlich angezeigt
         index_url: Ermöglicht den automatischer Import mehrerer Mensen
         maintainer_wanted: Zeigt einen Hinweis zur Unterstützung auf der Mensa-Seite an
+      user:
+        email: "Nicht öffentlich."
+        notify_email: "Nicht öffentlich. Für Benachrichtigungen bei z.B. Fehlern deiner Parser."
+        public_name: Optional. Wird in den Parser-Informationen zur Mensa angezeigt.
+        public_email: Optional. Wird in den Parser-Informationen zur Mensa angezeigt.
+        info_url: Optional. Wird in den Parser-Informationen zur Mensa angezeigt.
     placeholders:
       canteen:
         url: https://mydomain.de/mensa-greuther-fuerth.xml

--- a/app/views/developers/show.html.slim
+++ b/app/views/developers/show.html.slim
@@ -21,25 +21,19 @@
           ' Zusätzlich kannst du weitere Informationen angeben, die bei von dir bereitgestellten Mensen angezeigt werden; beispielsweise, um es anderen Interessierten zu ermöglichen dir bei der Entwickler des Parsers zu helfen.
         h3
           ' Werde Entwickler!
+
         = render partial: "common/flash", object: flash[:user]
+
         - if @user.developer?
           p
-            ' Schon alles geschehen!
+            .alert.alert-success
+              = t("message.activate.already_developer")
         - else
-          = form_for @user, url: user_developer_path do |f|
-            p
-              = f.label :notify_email, t(:profile, :notify_email), required: true
-              = f.text_field :notify_email, placeholder: @user.email, required: true
-            p
-              = f.label :public_name, t(:profile, :public_name)
-              = f.text_field :public_name
-            p
-              = f.label :public_email, t(:profile, :public_email)
-              = f.text_field :public_email
-            p
-              = f.label :info_url, t(:profile, :info_url)
-              = f.text_field :info_url
-            p
-              input.btn-primary type="submit" value="Werde Entwickler"
+          = simple_form_for(@user, url: user_developer_path(@user)) do |f|
+            = f.input :notify_email, required: true
+            = f.input :public_name
+            = f.input :public_email
+            = f.input :info_url
+            = f.button :submit, value: "Werde Entwickler"
 
   = render partial: "users/nav"

--- a/app/views/sessions/new.html.slim
+++ b/app/views/sessions/new.html.slim
@@ -7,6 +7,6 @@
         .content
           .ident-buttons
             - Rails.configuration.omniauth_services.each do |id|
-              = form_tag auth_path(id) do
+              = form_tag(auth_path(id), data: { turbo: false }) do
                 button type="submit" class="btn btn-login btn-social btn-#{id}" title=t(:service, id)
                   = t(:service, id)

--- a/app/views/sessions/register.html.slim
+++ b/app/views/sessions/register.html.slim
@@ -1,4 +1,4 @@
-= simple_form_for @user, method: :put, url: register_path do |f|
+= simple_form_for(@user, method: :put, url: register_path) do |f|
   = render partial: "common/errors", locals: {model: @user}
   .row
     .span6

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -5,30 +5,17 @@
         h2 = t :my_profile
       .content
         = render partial: "common/flash", object: flash[:user]
-        = form_for @user do |f|
-          p
-            = f.label :name, t(:profile, :name)
-            = f.text_field :name
-          p
-            = f.label :email, t(:profile, :email)
-            = f.text_field :email
+        = simple_form_for(@user) do |f|
+          = f.input :name
+          = f.input :email
           - if @user.developer?
             fieldset
-              legend = t :profile, :developer_settings
-              p
-                = f.label :notify_email, t(:profile, :notify_email)
-                = f.text_field :notify_email, placeholder: @user.email
-              p
-                = f.label :public_name, t(:profile, :public_name)
-                = f.text_field :public_name
-              p
-                = f.label :public_email, t(:profile, :public_email)
-                = f.text_field :public_email
-              p
-                = f.label :info_url, t(:profile, :info_url)
-                = f.text_field :info_url
-          p
-            input.btn-primary type="submit" value=t(:save)
+              legend = t(:profile, :developer_settings)
+              = f.input :notify_email, placeholder: @user.email
+              = f.input :public_name
+              = f.input :public_email
+              = f.input :info_url
+          = f.button :submit
         - unless @user.developer?
           p
             = link_to user_developer_path(@user), class: "btn btn-primary", title: "Mehr zu Entwickler-Funktionen" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,14 +28,14 @@ Rails.application.routes.draw do
     resources :messages, path: "m", only: [:index]
   end
 
-  resources :users, path: "u" do
-    resources :favorites, path: "favs", only: [:index]
-    resources :identities, path: "ids", only: %i[new create destroy]
+  resources :users do
+    resources :favorites, only: [:index]
+    resources :identities, only: %i[new create destroy]
     resource :developer
   end
   get "activate/:token", to: "developers#activate", as: :activate
 
-  resources :favorites, path: "favs", only: [:index]
+  resources :favorites, only: [:index]
   resources :sources, only: %i[update edit] do
     resources :feeds, only: [:create]
   end

--- a/spec/system/developer_spec.rb
+++ b/spec/system/developer_spec.rb
@@ -26,7 +26,7 @@ describe "Developers" do
     it "I want to become a developer" do
       click_on "Aktiviere Entwickler-Funktionen"
 
-      fill_in "E-Mail für Fehlerberichte und ähnliches",
+      fill_in "E-Mail für Fehlerberichte",
         with: "test@example.org"
 
       click_on "Werde Entwickler"
@@ -148,7 +148,7 @@ describe "Developers" do
         expect(developer.public_email).to be_nil
         expect(developer.info_url).to be_nil
 
-        fill_in "Website", with: "http://example.org"
+        fill_in "Webseite", with: "http://example.org"
         fill_in "Öffentlicher Name", with: "Hans Otto"
         fill_in "Öffentliche E-Mail", with: "openmensa@example.org"
         click_on "Speichern"

--- a/spec/system/profile_spec.rb
+++ b/spec/system/profile_spec.rb
@@ -15,13 +15,13 @@ describe "Profile page" do
     expect(page).to have_content("E-Mail")
 
     fill_in "Name", with: "Boby Short"
-    fill_in "E-Mail (nicht öffentlich, wird für", with: "boby@altimos.de"
+    fill_in "E-Mail", with: "boby@altimos.de"
     click_on "Speichern"
 
     expect(page).to have_content("Profil gespeichert.")
 
     expect(find_field("Name").value).to eq("Boby Short")
-    expect(find_field("E-Mail (nicht öffentlich, wird für").value).to eq("boby@altimos.de")
+    expect(find_field("E-Mail").value).to eq("boby@altimos.de")
   end
 
   it "raises error when user tries to update with empty name" do
@@ -29,12 +29,12 @@ describe "Profile page" do
     expect(page).to have_content("E-Mail")
 
     fill_in "Name", with: ""
-    fill_in "E-Mail (nicht öffentlich, wird für", with: "boby@altimos.de"
+    fill_in "E-Mail", with: "boby@altimos.de"
     click_on "Speichern"
 
     expect(page).to have_content("muss ausgefüllt werden")
     expect(find_field("Name").value).to eq("")
-    expect(find_field("E-Mail (nicht öffentlich, wird für").value).to eq("boby@altimos.de")
+    expect(find_field("E-Mail").value).to eq("boby@altimos.de")
   end
 
   it "allows user to add an identity" do


### PR DESCRIPTION
Build forms with simple form, to have correct localizable attributes names and hints, and proper validation.

Fix a bug of developer mode form ignoring the notify email presence validation because, when validation, developer isn't set.