### PR TITLE
Create and sync sources w/o canteen data

### DIFF
--- a/app/controllers/parsers_controller.rb
+++ b/app/controllers/parsers_controller.rb
@@ -32,7 +32,7 @@ class ParsersController < WebController
   end
 
   def sync
-    @synchroniser = OpenMensa::ParserUpdater.new @parser
+    @synchroniser = OpenMensa::ParserUpdater.new(@parser)
     @synchroniser.sync
   end
 

--- a/app/javascripts/_buttons.scss
+++ b/app/javascripts/_buttons.scss
@@ -206,40 +206,11 @@ $btn-success: #238625 !default;
 }
 
 .btn-group {
-  a {
-    @extend .btn;
-    border-radius: 0;
-    border-right-width: 0;
+  display: flex;
+  gap: 0.4em;
+
+  > .btn {
     margin: 0;
-
-    display: block;
-    float: left;
-
-    &:hover,
-    &:active,
-    &.active,
-    &.current,
-    &:focus,
-    &.focus {
-      border-right-width: 1px;
-      + a {
-        border-left-width: 0;
-      }
-    }
-
-    &:first-child {
-      border-top-left-radius: 2px;
-      border-bottom-left-radius: 2px;
-    }
-    &:last-child {
-      border-top-right-radius: 2px;
-      border-bottom-right-radius: 2px;
-      border-right-width: 1px;
-    }
-  }
-
-  &.btn-small a {
-    @extend .btn-small;
   }
 }
 

--- a/app/locales/de.yml
+++ b/app/locales/de.yml
@@ -224,6 +224,8 @@ de:
           lastday: "Letzte 24h:"
           lastweek: "Letzte Woche:"
           lastyear: "Letztes Jahr:"
+    sync:
+      back: Zurück zum Parser
 
   source:
     resource: Quelle

--- a/app/locales/de.yml
+++ b/app/locales/de.yml
@@ -201,18 +201,6 @@ de:
         feedbacks: Nutzerrückmeldungen
         messages: Nachrichten
         source: Quelle
-        actions:
-          source:
-            edit: "Editiere %{name} (Quelle)"
-            messages:
-              open: "Mitteilungen für %{name} anzeigen"
-          canteen:
-            edit: "Editiere %{name} (Mensa)"
-            open: "Öffne %{name}"
-          feedbacks:
-            open: "Nutzerrückmeldungen für %{name} anzeigen"
-          data_proposals:
-            open: "Änderungsvorschläge für %{name} anzeigen"
       feeds:
         headline: Feedstatus
         status:
@@ -226,6 +214,20 @@ de:
           lastyear: "Letztes Jahr:"
     sync:
       back: Zurück zum Parser
+    row:
+      sources:
+        actions:
+          source:
+            edit: "Editiere %{name} (Quelle)"
+            messages:
+              open: "Mitteilungen für %{name} anzeigen"
+          canteen:
+            edit: "Editiere %{name} (Mensa)"
+            open: "Öffne %{name}"
+          feedbacks:
+            open: "Nutzerrückmeldungen für %{name} anzeigen"
+          data_proposals:
+            open: "Änderungsvorschläge für %{name} anzeigen"
 
   source:
     resource: Quelle
@@ -433,6 +435,9 @@ de:
       user:
         one: Benutzer
         other: Benutzer
+      source:
+        one: Quelle
+        other: Quellen
     attributes:
       canteen:
         address: Adresse

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -3,7 +3,7 @@
 class Source < ApplicationRecord
   include ActiveModel::ForbiddenAttributesProtection
 
-  belongs_to :canteen
+  belongs_to :canteen, optional: true
   belongs_to :parser
   has_many :feeds, -> { order(:priority) }, inverse_of: :source, dependent: :destroy
   has_many :messages, as: :messageable, dependent: :destroy

--- a/app/views/parsers/_row.html.slim
+++ b/app/views/parsers/_row.html.slim
@@ -1,0 +1,20 @@
+tr
+  td.first
+    = link_to edit_source_path(source), title: t('.sources.actions.source.edit', name: source.name) do
+      = source.name
+  - if source.canteen.present?
+    td = link_to edit_canteen_path(source.canteen), title: t('.sources.actions.canteen.edit', name: source.canteen.name) do
+          = source.canteen.name
+    td = link_to canteen_path(source.canteen), title: t('.sources.actions.canteen.open', name: source.canteen.name) do
+          i.icon.fa-fw.fa-solid.fa-arrow-up-right-from-square
+    td = source.canteen.city
+  - else
+    td colspan="3"
+  td.number = source.feeds.count
+  td.number = link_to source.messages.count, source_messages_path(source), title: t('.sources.actions.source.messages.open', name: source.name)
+
+  - if source.canteen.present?
+    td.number = link_to source.canteen.feedbacks.count, canteen_feedbacks_path(source.canteen), title: t('.sources.actions.feedbacks.open', name: source.canteen.name)
+    td.number.last = link_to source.canteen.data_proposals.count, canteen_data_proposals_path(source.canteen), title: t('.sources.actions.data_proposals.open', name: source.canteen.name)
+  - else
+    td.last colspan="2"

--- a/app/views/parsers/show.html.slim
+++ b/app/views/parsers/show.html.slim
@@ -47,22 +47,10 @@
             i.fa-fw.fa-regular.fa-comments title=t('.sources.feedbacks')
           th.number.last
             i.fa-fw.fa-solid.fa-right-left title=t('.sources.data_proposals')
-        - @sources.each do |s|
-          tr
-            td.first
-              = link_to edit_source_path(s), title: t('.sources.actions.source.edit', name: s.name) do
-                = s.name
-            td
-              = link_to edit_canteen_path(s.canteen), title: t('.sources.actions.canteen.edit', name: s.canteen.name) do
-                = s.canteen.name
-            td
-              = link_to canteen_path(s.canteen), title: t('.sources.actions.canteen.open', name: s.canteen.name) do
-                i.icon.fa-fw.fa-solid.fa-arrow-up-right-from-square
-            td = s.canteen.city
-            td.number = s.feeds.count
-            td.number = link_to s.messages.count, source_messages_path(s), title: t('.sources.actions.source.messages.open', name: s.name)
-            td.number = link_to s.canteen.feedbacks.count, canteen_feedbacks_path(s.canteen), title: t('.sources.actions.feedbacks.open', name: s.canteen.name)
-            td.number.last = link_to s.canteen.data_proposals.count, canteen_data_proposals_path(s.canteen), title: t('.sources.actions.data_proposals.open', name: s.canteen.name)
+        - @sources.where(canteen: nil).each do |source|
+          = render(partial: 'row', locals: { source: })
+        - @sources.where.not(canteen: nil).each do |source|
+          = render(partial: 'row', locals: { source: })
 
     section
       header
@@ -84,7 +72,7 @@
             i.fa-fw.fa-solid.fa-triangle-exclamation title=t(:feed_fetch, :states, :failed)
           th.number.last
             i.fa-fw.fa-solid.fa-bolt title=t(:feed_fetch, :states, :broken)
-        - @sources.each do |s|
+        - @sources.where.not(canteen: nil).each do |s|
           - s.feeds.each_with_index do |f, i|
             - f.feed_timespans.each do |span, fetches|
               tr

--- a/app/views/parsers/sync.html.slim
+++ b/app/views/parsers/sync.html.slim
@@ -4,13 +4,15 @@
       header
         h2 = t :parser, :sync
       .content
-          p
-            = t :parser, :synced
-            ul
-              li = t :parser, :sources_added, count: @synchroniser.sources_added
-              li = t :parser, :sources_created, count: @synchroniser.sources_created
-              li = t :parser, :sources_updated, count: @synchroniser.sources_updated
-              li = t :parser, :sources_deleted, count: @synchroniser.sources_deleted
+        p
+          = t :parser, :synced
+          ul
+            li = t :parser, :sources_added, count: @synchroniser.sources_added
+            li = t :parser, :sources_created, count: @synchroniser.sources_created
+            li = t :parser, :sources_updated, count: @synchroniser.sources_updated
+            li = t :parser, :sources_deleted, count: @synchroniser.sources_deleted
+        p.btn-group
+          = link_to(t(".back"), parser_path(@parser), class: "btn btn-primary")
 
   aside.span4
     = render partial: "users/nav"

--- a/app/views/sources/edit.html.slim
+++ b/app/views/sources/edit.html.slim
@@ -4,35 +4,31 @@
       header
         h2 = t :edit_source
       .content
-        = form_for @source do |form|
+        = simple_form_for(@source) do |form|
           = render partial: "form", object: form
-          p
-            = form.label :parser_id, t(:source, :parser)
-            = form.select(:parser_id, current_user.parsers.map {|p| [p.name, p.id] })
-          p
-            = submit_tag t(:save)
+          = form.button :submit
+        p
           - if @source.meta_url.present?
             = link_to sync_source_path(@source), class: "btn btn-primary", title: "Synchronisiere Feeds", method: :post do
               = "Synchronisiere Feeds mittels Meta-URL"
+
     - if @source.meta_url.blank?
       section
         header
           h2 = t :new_feed
         .content
-          = form_for [@source, @new_feed] do |form|
+          = simple_form_for([@source, @new_feed]) do |form|
             = render partial: "feeds/form", object: form
-            p
-              = submit_tag t(:create_feed)
+            = form.button :submit
       - @source.feeds.reject(&:new_record?).each do |feed|
         section
           header
-            h2 = t :edit_feed, name: feed.name
+            h2 = t(:edit_feed, name: feed.name)
           .content
-            = form_for feed do |form|
+            = simple_form_for(feed) do |form|
               = render partial: "feeds/form", object: form
-              p
-                = submit_tag t(:save)
-              p
+              p.btn-group
+                = form.button :submit
                 = link_to feed_path(feed), class: "btn btn-danger", title: "Löschen", method: :delete do
                   = "Löschen"
 

--- a/app/views/sources/messages.html.slim
+++ b/app/views/sources/messages.html.slim
@@ -1,7 +1,8 @@
 .row
   .span8
     section
-      = render partial: "canteens/canteen_header", locals: {user: current_user, canteen: @source.canteen}
+      - if @source.canteen.present?
+        = render partial: "canteens/canteen_header", locals: {user: current_user, canteen: @source.canteen}
 
       header
         h2
@@ -18,6 +19,7 @@
 
   aside.span4
     = render partial: "common/favorites", locals: {user: current_user}
-    - if current_user.can? :manage, @source.canteen
-      = render partial: "common/canteen_actions", locals: {canteen: @source.canteen}
-    = render partial: "canteens/canteen_status", locals: {canteen: @source.canteen}
+    - if @source.canteen.present?
+      - if current_user.can?(:manage, @source.canteen)
+        = render partial: "common/canteen_actions", locals: {canteen: @source.canteen}
+      = render partial: "canteens/canteen_status", locals: {canteen: @source.canteen}

--- a/lib/open_mensa/base_updater.rb
+++ b/lib/open_mensa/base_updater.rb
@@ -23,11 +23,11 @@ class OpenMensa::BaseUpdater
     end
     version
   rescue OpenMensa::FeedValidator::InvalidFeedVersionError
-    create_validation_error! :unknown_version
+    create_validation_error!(:unknown_version)
     false
   rescue OpenMensa::FeedValidator::FeedValidationError => e
     e.errors.take(2).each do |error|
-      create_validation_error! :invalid_xml, error.message
+      create_validation_error!(:invalid_xml, error.message)
     end
     false
   end
@@ -35,16 +35,20 @@ class OpenMensa::BaseUpdater
   private
 
   def create_validation_error!(kind, message = nil)
-    @errors << FeedValidationError.create!(messageable:,
+    @errors << FeedValidationError.create!(
+      messageable:,
       version:,
       message:,
-      kind:,)
+      kind:,
+    )
   end
 
   def create_fetch_error!(message, code = nil)
-    @errors << FeedFetchError.create(messageable:,
+    @errors << FeedFetchError.create(
+      messageable:,
       message:,
-      code:,)
+      code:,
+    )
   end
 
   def extract_canteen_node

--- a/lib/open_mensa/source_creator.rb
+++ b/lib/open_mensa/source_creator.rb
@@ -5,15 +5,15 @@ class OpenMensa::SourceCreator < OpenMensa::SourceUpdater
 
   # 4. all together
   def sync
-    return false unless fetch! && parse! && validate!
+    return unless fetch! && parse! && validate!
 
-    canteen = create_canteen extract_canteen_node
-    return false if canteen.nil? || !canteen.valid?
+    canteen = create_canteen(extract_canteen_node)
+    return if canteen.nil? || !canteen.valid?
 
     source.canteen = canteen
     source.save
 
-    create_feeds extract_canteen_node
+    create_feeds(extract_canteen_node)
 
     true
   end
@@ -24,9 +24,8 @@ class OpenMensa::SourceCreator < OpenMensa::SourceUpdater
     canteen.element_children.select do |node|
       next unless node.name == "feed"
 
-      create_feed node
+      create_feed(node)
     end
-    true
   end
 
   def create_canteen(canteen_node)

--- a/spec/lib/open_mensa/parser_updater_spec.rb
+++ b/spec/lib/open_mensa/parser_updater_spec.rb
@@ -2,8 +2,6 @@
 
 require "spec_helper"
 
-include Nokogiri
-
 describe OpenMensa::ParserUpdater do
   let(:parser) { create(:parser, index_url: "http://example.com/index.json") }
   let(:updater) { OpenMensa::ParserUpdater.new(parser) }
@@ -19,20 +17,20 @@ describe OpenMensa::ParserUpdater do
   end
 
   describe "#fetch" do
-    it "skips invalid urls" do
-      parser.update_attribute :index_url, ":///:asdf"
+    it "skips invalid URLs" do
+      parser.update_attribute(:index_url, ":///:asdf")
       expect(updater.fetch!).to be_falsey
       m = parser.messages.first
       expect(m).to be_an_instance_of(FeedInvalidUrlError)
       expect(updater.errors).to eq([m])
     end
 
-    it "receives feed data via http" do
+    it "receives feed data via HTTP" do
       stub_data "{}"
       expect(updater.fetch!.read).to eq("{}")
     end
 
-    it "updates index url on 301 responses" do
+    it "updates index UR on 301 responses" do
       stub_request(:any, "example.com/301.json")
         .to_return(status: 301, headers: {location: "http://example.com/index.json"})
       stub_data "{}"
@@ -45,7 +43,7 @@ describe OpenMensa::ParserUpdater do
       expect(m.new_url).to eq("http://example.com/index.json")
     end
 
-    it "does not update index url on 302 responses" do
+    it "does not update index URL on 302 responses" do
       stub_request(:any, "example.com/302.json")
         .to_return(status: 302, headers: {location: "http://example.com/index.json"})
       stub_data "{}"
@@ -54,7 +52,7 @@ describe OpenMensa::ParserUpdater do
       expect(parser.reload.index_url).to eq("http://example.com/302.json")
     end
 
-    it "handles http errors correctly" do
+    it "handles HTTP errors correctly" do
       stub_request(:any, "example.com/500.json")
         .to_return(status: 500)
       parser.update_attribute :index_url, "http://example.com/500.json"
@@ -89,7 +87,7 @@ describe OpenMensa::ParserUpdater do
   end
 
   describe "#parse" do
-    it "parses valid json" do
+    it "parses valid JSON" do
       stub_data('{"test": "http://example.org/test.xml",
                   "test2": null}')
       expect(updater.fetch!).to be_truthy
@@ -99,17 +97,7 @@ describe OpenMensa::ParserUpdater do
       )
     end
 
-    it "parses valid json" do
-      stub_data('{"test": "http://example.org/test.xml",
-                  "test2": null}')
-      expect(updater.fetch!).to be_truthy
-      expect(updater.parse!).to eq(
-        "test" => "http://example.org/test.xml",
-        "test2" => nil,
-      )
-    end
-
-    it "fails on invalid json" do
+    it "fails on invalid JSON" do
       stub_data('{"test": "http://example.org/test.xml",
                   "test2": nil}{')
       expect(updater.fetch!).to be_truthy
@@ -139,7 +127,7 @@ describe OpenMensa::ParserUpdater do
       end
     end
 
-    it "valid but expected json (invalid value for name)" do
+    it "valid but expected JSON (invalid value for name)" do
       stub_data('{"test": 4}')
       expect(updater.fetch!).to be_truthy
       expect(updater.parse!).to be_truthy
@@ -154,7 +142,7 @@ describe OpenMensa::ParserUpdater do
       end
     end
 
-    it "valid but expected json (invalid value for name 2)" do
+    it "valid but expected JSON (invalid value for name 2)" do
       stub_data('{"test": {"test": "http://test.xml"}}')
       expect(updater.fetch!).to be_truthy
       expect(updater.parse!).to be_truthy
@@ -250,7 +238,7 @@ describe OpenMensa::ParserUpdater do
       end
     end
 
-    it "create message for new source without url" do
+    it "create message for new source without URL" do
       stub_json test: nil
 
       expect(updater.sync).to be_truthy
@@ -264,7 +252,7 @@ describe OpenMensa::ParserUpdater do
       end
     end
 
-    it "updates source urls" do
+    it "updates source URLs" do
       stub_json test: "http://example.com/test/meta.xml"
       source = create(:source, parser:,
         name: "test",
@@ -281,7 +269,7 @@ describe OpenMensa::ParserUpdater do
       end
     end
 
-    it "adds source urls if not existing" do
+    it "adds source URLs if not existing" do
       stub_json test: "http://example.com/test/meta.xml"
       source = create(:source, parser:,
         name: "test",
@@ -298,7 +286,7 @@ describe OpenMensa::ParserUpdater do
       end
     end
 
-    it "adds source urls if not existing" do
+    it "adds source URLs if not existing" do
       stub_json({})
       source = create(:source, parser:,
         name: "test",

--- a/spec/system/developer2_spec.rb
+++ b/spec/system/developer2_spec.rb
@@ -116,7 +116,7 @@ describe "Developers" do
 
           within(:xpath, '//section[header="Editiere Quelle"]') do
             fill_in "Name", with: "Testname"
-            click_on "Speichern"
+            click_on "Quelle aktualisieren"
           end
 
           expect(page).to have_content "Testname"
@@ -133,7 +133,7 @@ describe "Developers" do
             fill_in "Wiederholungsinterval(e)", with: "10 3"
           end
 
-          click_on "Feed anlegen"
+          click_on "Feed erstellen"
 
           expect(page).to have_content "Der neuer Feed wurde erfolgreich angelegt."
           expect(page).to have_content "Feed Full"
@@ -146,7 +146,7 @@ describe "Developers" do
           within(:xpath, "//section[header=\"Feed #{feed.name}\"]") do
             fill_in "Name", with: "Replacefeed"
             fill_in "Wiederholungsinterval(e)", with: ""
-            click_on "Speichern"
+            click_on "Feed aktualisieren"
           end
 
           expect(page).to have_content "Der Feed wurde erfolgreich aktualisiert."


### PR DESCRIPTION
Keep track of sources w/o canteens when syncing from the index URL so that they are not reported as new every time.