### PR TITLE
fix(mail/parser): Handle optional canteen on source

### DIFF
--- a/app/mailers/parser_mailer.rb
+++ b/app/mailers/parser_mailer.rb
@@ -144,8 +144,8 @@ class ParserMailer < ApplicationMailer
         FeedMailerPart.new feed, data_since
       end
       @messages = source.messages.where("created_at > ?", data_since).to_a
-      @feedbacks = source.canteen.feedbacks.where("created_at > ?", data_since).to_a
-      @data_proposals = source.canteen.data_proposals.where("created_at > ?", data_since).to_a
+      @feedbacks = source.canteen&.feedbacks&.where("created_at > ?", data_since).to_a
+      @data_proposals = source.canteen&.data_proposals&.where("created_at > ?", data_since).to_a
     end
 
     def notable?

--- a/app/views/parser_mailer/daily_report.de.text.erb
+++ b/app/views/parser_mailer/daily_report.de.text.erb
@@ -8,7 +8,11 @@ Mehr Information finden Sie unter:
 <% end %>
 <% @notables.each do |source| %>
 
-<%=source.canteen.name %> (<%= source.name %>)
+<% if source.canteen.present? %>
+<%= source.canteen.name %> (<%= source.name %>)
+<% else %>
+<%= source.name %>
+<% end %>
 ===================
 <% source.messages.each do |message| %>
 

--- a/spec/mailers/parser_mailer_spec.rb
+++ b/spec/mailers/parser_mailer_spec.rb
@@ -62,6 +62,38 @@ describe ParserMailer do
         end
       end
 
+      context "that has no canteen" do
+        let(:source) { create(:source, parser:, canteen: nil) }
+
+        it "does not send a mail" do
+          expect(mail).to be_null_mail
+        end
+
+        context "with source message" do
+          before { source_message }
+
+          it "sends a mail" do
+            expect(mail).not_to be_null_mail
+
+            pp mail.body
+
+            expect(mail.to).to eq [user.notify_email]
+            expect(mail.subject).to eq "OpenMensa - #{parser.name}: Unregelmäßigkeiten mit #{source.name}"
+            expect(mail.body).to include source_message.to_text_mail
+          end
+
+          it "has a combined subject with parser messages" do
+            parser_message
+            expect(mail).not_to be_null_mail
+
+            expect(mail.to).to eq [user.notify_email]
+            expect(mail.subject).to eq "OpenMensa - #{parser.name}: Unregelmäßigkeiten mit dem Parser selbst, #{source.name}"
+            expect(mail.body).to include parser_message.to_text_mail
+            expect(mail.body).to include source_message.to_text_mail
+          end
+        end
+      end
+
       context "with source message" do
         before { source_message }
 


### PR DESCRIPTION
Check if `source.canteen` exists before using it.