### PR TITLE
chore: Add broader ecosystem checks workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,53 @@
+# Broader ecosystem checks for the repository, such as linting actions
+# for workflows or security checks.
+#
+# Nothing directly related to the application codebase, language, code
+# formatting or quality, or frameworks should be added here. Those
+# should be added to `test.yml` instead.
+---
+name: Check
+
+on:
+  push:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Check workflow files
+        run: |
+          echo "::add-matcher::.github/actionlint-matcher.json"
+          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          ./actionlint
+
+  zizmor:
+    runs-on: ubuntu-24.04
+
+    permissions:
+      security-events: write
+
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          advanced-security: false

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,5 @@
 ---
-name: docs
+name: Docs
 
 on:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 ---
-name: test
+name: Test
 
 on:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,22 +111,6 @@ jobs:
       - run: yarn install --immutable
       - run: yarn run lint:fmt
 
-  actionlint:
-    runs-on: ubuntu-24.04
-
-    steps:
-      - uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
-        with:
-          egress-policy: audit
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-      - name: Check workflow files
-        run: |
-          echo "::add-matcher::.github/actionlint-matcher.json"
-          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-          ./actionlint
-
   docker:
     needs: rspec
     if: always()


### PR DESCRIPTION
Move the GitHub Actions workflow checks for the repository ecosystem, such as workflow linting and security checks, to a new `check.yml` workflow. This keeps the `test.yml` workflow focused on application codebase checks, such as tests, language-specific linting, code formatting, and code quality checks.

The new `zizmor` security check adds static analysis for security issues in workflow files.